### PR TITLE
Fix Dockerfile build without .env file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN apk --no-cache add ca-certificates sqlite-libs
 
 WORKDIR /root/
 
-COPY --from=builder /usr/src/app/.env .env
 COPY --from=builder /usr/src/app/app .
 
 CMD ["./app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ COPY . .
 # Build with CGO enabled for SQLite support
 RUN CGO_ENABLED=1 GOOS=linux go build -a -ldflags '-linkmode external -extldflags "-static"' -o app .
 
+# Create empty .env if it doesn't exist (to avoid COPY failure)
+RUN test -f .env || touch .env
+
 FROM alpine:3.21
 
 # Install runtime dependencies
@@ -20,6 +23,7 @@ RUN apk --no-cache add ca-certificates sqlite-libs
 
 WORKDIR /root/
 
+COPY --from=builder /usr/src/app/.env .env
 COPY --from=builder /usr/src/app/app .
 
 CMD ["./app"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build process to ensure consistent .env file availability across build stages, preventing potential deployment configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->